### PR TITLE
Remove the GUM links as they don't render with chrome:// protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It allows you to make screenshots and record a video of your desktop from your b
 
 ## How to use
 
-JSCapture uses `getUserMedia` for screen capturing. Currently the API for screen capturing is supported only by Google Chrome, Canary and Chromium by enabling an experimental [flag][chromeFlag].
+JSCapture uses `getUserMedia` for screen capturing. Currently the API for screen capturing is supported only by Google Chrome, Canary and Chromium by enabling an experimental flag.
 
 In order to enable the flag:
 
@@ -16,7 +16,7 @@ In order to enable the flag:
 
 Note that you MUST use `https` in order to be allowed to do screen recording. Since there are some **very expensive** operations happening when each frame is being captured the video won't be useful when you're capturing a high resolution. In order to handle this issue use the `scale` property.
 
-When you're done and you open [chrome://flags/#enable-usermedia-screen-capture][chromeFlag], you should see something like:
+When you're done and you open chrome://flags/#enable-usermedia-screen-capture, you should see something like:
 
 ![Chrome flags](http://bulgariajs.org/files/getusermedia-flag.png)
 


### PR DESCRIPTION
Sorry about my mess up earlier. Markdown doesn't render `chrome://` protocol links.
